### PR TITLE
Add git and db init to Dockerfile

### DIFF
--- a/REST_API/.dockerignore
+++ b/REST_API/.dockerignore
@@ -2,5 +2,3 @@ JSON-build-params/*
 venv
 build_and_push.sh
 docker-compose.yml
-Makefile
-

--- a/REST_API/Dockerfile-flask
+++ b/REST_API/Dockerfile-flask
@@ -21,7 +21,7 @@ RUN pip wheel --wheel-dir=/root/wheels -r requirements.txt
 FROM python:3.6-alpine as small
 
 # Install prerequisites
-RUN apk add build-base libffi-dev postgresql-dev bash
+RUN apk add build-base libffi-dev postgresql-dev bash git
 
 # copy python packages from big image
 COPY requirements.txt .
@@ -34,6 +34,9 @@ WORKDIR $APP
 
 # We copy codebase into the image
 COPY . .
+
+# Init database
+RUN make database
 
 # Expose the port uWSGI will listen on
 EXPOSE 5000

--- a/REST_API/docker-compose.yml
+++ b/REST_API/docker-compose.yml
@@ -9,7 +9,6 @@ services:
       context: .
       dockerfile: Dockerfile-flask
     volumes:
-      - "./:/image-builder"
       - "/var/run/docker.sock:/var/run/docker.sock"
 
   nginx:
@@ -23,4 +22,4 @@ services:
     depends_on:
       - flask
     volumes:
-      - "/etc/ssl/certs:/etc/nginx/certs"
+      - "/home/xopera/certs:/etc/nginx/certs"


### PR DESCRIPTION
This PR ads two missing required features to docker image. It installs git, which is necessary for image-builder and adds empty database instance.