### PR TITLE
Execute Docker image build relative to cloned git repo

### DIFF
--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
@@ -114,13 +114,18 @@
       docker_image:
         source: build
         build:
-          path: "{{ workdir }}"
+          path: "{{ workdir }}/{{ dir_name }}"
+          dockerfile: "{{ workdir }}/Dockerfile"
           pull: yes
         name: "{{ target.image_name }}"
         force_source: yes
         repository: "{{ target.registry_ip }}/{{ target.image_name }}:{{ target.image_tag }}"
         push: yes
+      vars:
+        item_as_item: "{{ item | dict2items | first }}"
+        dir_name: "{{ item_as_item.key }}"
       when: source.type == dockerfile_type
+      loop: "{{ build_context }}"
 
     - name: Load image from archive and push it
       docker_image:


### PR DESCRIPTION
Dockerfiles expect to be running within the source tree, as they rely on
relative file paths for e.g. COPY operations. We use a two-step approach
here: (1) Prefer the Dockerfile in the top-level working directory, as
this is fetched independently; and (2) Provide the full path to the
cloned repository for the image build itself.

Fixes SODALITE-EU/image-builder#5