### PR TITLE
 Support building image variants with layered base containers

### DIFF
--- a/REST_API/JSON-build-params/vehicle-iot-uc/edgetpu-exporter-variants.json
+++ b/REST_API/JSON-build-params/vehicle-iot-uc/edgetpu-exporter-variants.json
@@ -1,0 +1,21 @@
+{
+  "source_type": "Dockerfile",
+  "source_url": "https://raw.githubusercontent.com/adaptant-labs/edgetpu-exporter/master/Dockerfile",
+  "build_context": [
+    {
+      "dir_name": "edgetpu-exporter",
+      "url": "https://github.com/adaptant-labs/edgetpu-exporter"
+    }
+  ],
+  "target_images": [
+    {
+      "image": "adaptant/edgetpu-exporter",
+      "tag": "latest"
+    },
+    {
+      "image": "adaptant/edgetpu-exporter",
+      "tag": "go1.13",
+      "base": "golang:1.13"
+    }
+  ]
+}

--- a/REST_API/JSON-build-params/vehicle-iot-uc/edgetpu-exporter.json
+++ b/REST_API/JSON-build-params/vehicle-iot-uc/edgetpu-exporter.json
@@ -1,0 +1,12 @@
+{
+  "source_type": "Dockerfile",
+  "source_url": "https://raw.githubusercontent.com/adaptant-labs/edgetpu-exporter/master/Dockerfile",
+  "build_context": [
+    {
+      "dir_name": "edgetpu-exporter",
+      "url": "https://github.com/adaptant-labs/edgetpu-exporter"
+    }
+  ],
+  "target_image_name": "adaptant/edgetpu-exporter",
+  "target_image_tag": "latest"
+}

--- a/REST_API/app/main/service/image_builder/TOSCA/docker_image_definition.yaml
+++ b/REST_API/app/main/service/image_builder/TOSCA/docker_image_definition.yaml
@@ -61,6 +61,19 @@ data_types:
         default: ""
         description: Password for authentication (if needed) for git repo
 
+  mytypes.ImageVariant:
+    description: Image variant to build.
+    properties:
+      image:
+        type: string
+        description: Image name
+      tag:
+        type: string
+        description: Image tag
+      base:
+        type: string
+        description: Base image to inject
+
   mytypes.Target:
     description: Destination for built image.
     properties:
@@ -76,6 +89,13 @@ data_types:
         type: string
         required: true
         description: Target docker image tag.
+      images:
+        type: list
+        default: []
+        required: false
+        description: List of image variants to build.
+        entry_schema:
+          type: mytypes.ImageVariant
 
 node_types:
   my.nodes.image.builder:

--- a/REST_API/app/main/service/image_builder/TOSCA/inputs/generic/inputs-dockerfile.yaml
+++ b/REST_API/app/main/service/image_builder/TOSCA/inputs/generic/inputs-dockerfile.yaml
@@ -13,5 +13,16 @@ source:
 
 target:
   registry_ip: my_registry_ip
+
+  # For single images, define the following
   image_name: my_image_name
   image_tag: my_image_tag
+
+  # For image variants, define as follows:
+  images:
+    - image: my_image_name
+      tag: my_image_tag
+
+    - image: my_image_name
+      tag: my_image_variant_tag
+      base: my_image_variant_base_image

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
@@ -133,19 +133,19 @@
       args:
         # sed does a better job of this than the replace module, silence warnings about its use.
         warn: false
-      when: source.type == dockerfile_type and target.images is defined
+      when: source.type == dockerfile_type and target.images is defined and target.images is not none
 
     - name: Extract default base image from Dockerfile
       shell: sed q "{{ workdir }}/Dockerfile" | sed -e 's/^.*=//g'
       register: base_image_data
       args:
         warn: false
-      when: source.type == dockerfile_type and target.images is defined
+      when: source.type == dockerfile_type and target.images is defined and target.images is not none
 
     - name: Preserving default base image
       set_fact:
         default_base_image: "{{ base_image_data.stdout }}"
-      when: source.type == dockerfile_type and target.images is defined
+      when: source.type == dockerfile_type and target.images is defined and target.images is not none
 
     # Build and push image variants
     - name: Build image variants and push them
@@ -161,8 +161,8 @@
         force_source: yes
         repository: "{{ target.registry_ip }}/{{ item.image }}:{{ item.tag }}"
         push: yes
-      when: source.type == dockerfile_type and target.images is defined
-      loop: "{{ target.images }}"
+      when: source.type == dockerfile_type and target.images is defined and target.images is not none
+      loop: "{{ target.images | default([], True) }}"
 
     # Build and push a single target image
     - name: Build image and push it

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
@@ -135,6 +135,18 @@
         warn: false
       when: source.type == dockerfile_type and target.images is defined
 
+    - name: Extract default base image from Dockerfile
+      shell: sed q "{{ workdir }}/Dockerfile" | sed -e 's/^.*=//g'
+      register: base_image_data
+      args:
+        warn: false
+      when: source.type == dockerfile_type and target.images is defined
+
+    - name: Preserving default base image
+      set_fact:
+        default_base_image: "{{ base_image_data.stdout }}"
+      when: source.type == dockerfile_type and target.images is defined
+
     # Build and push image variants
     - name: Build image variants and push them
       docker_image:
@@ -143,8 +155,7 @@
           path: "{{ workdir }}/{{ dir_name }}"
           dockerfile: "{{ workdir }}/Dockerfile"
           args:
-            # Only override the base image if an override is defined for this variant
-            BASE_IMAGE: "{{ item.base | default(omit) }}"
+            BASE_IMAGE: "{{ item.base | default(default_base_image, true) }}"
           pull: yes
         name: "{{ item.image }}"
         force_source: yes

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
@@ -114,13 +114,18 @@
       docker_image:
         source: build
         build:
-          path: "{{ workdir }}"
+          path: "{{ workdir }}/{{ dir_name }}"
+          dockerfile: "{{ workdir }}/Dockerfile"
           pull: yes
         name: "{{ target.image_name }}"
         force_source: yes
         repository: "{{ target.registry_ip }}/{{ target.image_name }}:{{ target.image_tag }}"
         push: yes
+      vars:
+        item_as_item: "{{ item | dict2items | first }}"
+        dir_name: "{{ item_as_item.key }}"
       when: source.type == dockerfile_type
+      loop: "{{ build_context }}"
 
     - name: Load image from archive and push it
       docker_image:

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
@@ -16,8 +16,8 @@
           - source.url is defined and source.url is not none
           - (source.username is defined and source.username is not none) == (source.password is defined and source.password is not none)
           - target.registry_ip is defined and target.registry_ip is not none
-          - target.image_name is defined and target.image_name is not none
-          - target.image_tag is defined and target.image_tag is not none
+          - target.image_name is defined and target.image_name is not none or target.images is defined and target.images is not none
+          - target.image_tag is defined and target.image_tag is not none or target.images is defined and target.images is not none
 
     - name: set url
       set_fact:
@@ -110,6 +110,50 @@
         state: absent
       when: source.type == tar_type
 
+    - name: Set Git repo clone path
+      set_fact:
+        dir_name: "{{ repo_name }}"
+      vars:
+        item_as_item: "{{ item | dict2items | first }}"
+        repo_name: "{{ item_as_item.key }}"
+      when: source.type == dockerfile_type
+      loop: "{{ build_context }}"
+
+    - name: Preparing Dockerfile for BASE_IMAGE injection
+      # Match both 'FROM base' and 'FROM base as xxx' cases, with and without :version specifications.
+      # This will rewrite the first instance of the FROM line to be:
+      #
+      # ARG BASE_IMAGE=base:latest
+      # FROM ${BASE_IMAGE} as builder
+      #
+      # allowing the BASE_IMAGE to be overloaded by the image builder when building image variants.
+      shell: sed -i -e '1 s/\(FROM\) \([a-z:]*\)\([ \t].*$\)/ARG BASE_IMAGE=\2\n\1 \${BASE_IMAGE}\3/' \
+                    -e '1 s/\(FROM\) \([a-z:].*$\)/ARG BASE_IMAGE=\2\n\1 \${BASE_IMAGE}/' \
+                   "{{ workdir }}/Dockerfile"
+      args:
+        # sed does a better job of this than the replace module, silence warnings about its use.
+        warn: false
+      when: source.type == dockerfile_type and target.images is defined
+
+    # Build and push image variants
+    - name: Build image variants and push them
+      docker_image:
+        source: build
+        build:
+          path: "{{ workdir }}/{{ dir_name }}"
+          dockerfile: "{{ workdir }}/Dockerfile"
+          args:
+            # Only override the base image if an override is defined for this variant
+            BASE_IMAGE: "{{ item.base | default(omit) }}"
+          pull: yes
+        name: "{{ item.image }}"
+        force_source: yes
+        repository: "{{ target.registry_ip }}/{{ item.image }}:{{ item.tag }}"
+        push: yes
+      when: source.type == dockerfile_type and target.images is defined
+      loop: "{{ target.images }}"
+
+    # Build and push a single target image
     - name: Build image and push it
       docker_image:
         source: build
@@ -121,11 +165,7 @@
         force_source: yes
         repository: "{{ target.registry_ip }}/{{ target.image_name }}:{{ target.image_tag }}"
         push: yes
-      vars:
-        item_as_item: "{{ item | dict2items | first }}"
-        dir_name: "{{ item_as_item.key }}"
-      when: source.type == dockerfile_type
-      loop: "{{ build_context }}"
+      when: source.type == dockerfile_type and target.image_name is defined
 
     - name: Load image from archive and push it
       docker_image:
@@ -134,7 +174,7 @@
         source: load
         repository: "{{ target.registry_ip }}/{{ target.image_name }}:{{ target.image_tag }}"
         push: yes
-      when: source.type == tar_type
+      when: source.type == tar_type and target.image_name is defined
 
     - name: Clean workdir
       file:

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
@@ -116,8 +116,13 @@
       vars:
         item_as_item: "{{ item | dict2items | first }}"
         repo_name: "{{ item_as_item.key }}"
-      when: source.type == dockerfile_type
+      when: source.type == dockerfile_type and build_context is defined
       loop: "{{ build_context }}"
+
+    - name: Set repo_name when build_context is empty
+      set_fact:
+        dir_name: ""
+      when: source.type == dockerfile_type and dir_name is not defined
 
     - name: Preparing Dockerfile for BASE_IMAGE injection
       # Match both 'FROM base' and 'FROM base as xxx' cases, with and without :version specifications.

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
@@ -181,7 +181,7 @@
         force_source: yes
         repository: "{{ target.registry_ip }}/{{ target.image_name }}:{{ target.image_tag }}"
         push: yes
-      when: source.type == dockerfile_type and target.image_name is defined
+      when: source.type == dockerfile_type and target.image_name is defined and target.images is none
 
     - name: Load image from archive and push it
       docker_image:

--- a/REST_API/app/main/service/image_builder_service.py
+++ b/REST_API/app/main/service/image_builder_service.py
@@ -21,14 +21,21 @@ def validate(data: dict):
     url_username = data.get('source_username', None)
     url_pass = data.get('source_password', None)
     target_registry_ip = registry_ip
-    image_name = data['target_image_name']
-    image_tag = data['target_image_tag']
+    image_name = data.get('target_image_name', None)
+    image_tag = data.get('target_image_tag', None)
+
     try:
         build_context = [{element['dir_name']: {'url': element.get('url'), 'username': element.get('username', None),
                                                 'password': element.get('password', None)}} for element in
                          data['build_context']]
     except KeyError:
         build_context = None
+
+    try:
+        image_variants = [{'image': element.get('image'), 'tag': element.get('tag'), 'base': element.get('base', None)}
+                          for element in data['target_images']]
+    except KeyError:
+        image_variants = None
 
     return {
         "source": {
@@ -41,7 +48,8 @@ def validate(data: dict):
         "target": {
             "registry_ip": target_registry_ip,
             "image_name": image_name,
-            "image_tag": image_tag
+            "image_tag": image_tag,
+            "images": image_variants,
         }
     }
 

--- a/REST_API/app/main/util/dto.py
+++ b/REST_API/app/main/util/dto.py
@@ -31,6 +31,12 @@ class BuildDto:
         'password': fields.String(required=False, description='password for git')
     })
 
+    image_variant_context = api.model('image_variant_context', {
+        'image': fields.String(required=True, description='desired docker image name'),
+        'tag': fields.String(required=True, description='desired docker image tag'),
+        'base': fields.String(required=False, description='desired base image to build on')
+    })
+
     build_params = api.model('build_params', {
         'source_type': fields.String(required=True, description='"Dockerfile" or "tar"'),
         'source_url': fields.Url(required=True, description='url of Dockerfile or tar'),
@@ -38,8 +44,10 @@ class BuildDto:
         'source_password': fields.Url(required=False, description='password for Dockerfile or tar'),
         'build_context': fields.List(required=False, description='Build context, if building from Dockerfile',
                                      cls_or_instance=fields.Nested(git_context)),
-        'target_image_name': fields.String(required=True, description='desired docker image name'),
-        'target_image_tag': fields.String(required=False, default='latest', description='desired docker image tag')
+        'target_image_name': fields.String(required=False, description='desired docker image name'),
+        'target_image_tag': fields.String(required=False, default='latest', description='desired docker image tag'),
+        'target_images': fields.List(required=False, description='List of image variants to build',
+                                    cls_or_instance=fields.Nested(image_variant_context))
     })
 
 


### PR DESCRIPTION
By default, the image builder only builds a single image and pushes it
out. This introduces an additional approach, in which multiple images
can be built from the Dockerfile by overloading the base container that
the image is built from.

As ARG is permitted to be inserted before FROM in the Dockerfile, we
achieve this by first mangling the Dockerfile in-place to permit base
image overloading through a specified BASE_IMAGE argument that the
FROM directive refers to. As an example:

	FROM golang as builder

becomes:

	ARG BASE_IMAGE=golang
	FROM ${BASE_IMAGE} as builder

This has been applied both to single-stage and multi-stage builders with
success.

The input file is responsible for defining all of the different image
variant/base combinations that it wants to generate. While in practice
this will be used for layering services on top of different accelerator
runtimes, a synthetic example providing tagged images for different
versions of the language runtime is as follows:

	target:
	  registry_ip: localhost:5000
	  images:
	  - image: adaptant/edgetpu-exporter
	    tag: latest

	  - image: adaptant/edgetpu-exporter
	    tag: go1.13
	    base: golang:1.13

The image name can be, but must not, be the same for each variant. The
omission of the base property will default to the existing base image
defined within the Dockerfile.