### PR TITLE
add image-builder- prefix to container names

### DIFF
--- a/REST_API/app.conf
+++ b/REST_API/app.conf
@@ -7,7 +7,7 @@ server {
     location / { try_files $uri @app; }
     location @app {
         include uwsgi_params;
-        uwsgi_pass flask:5000;
+        uwsgi_pass image-builder-flask:5000;
     }
 }
 
@@ -24,7 +24,7 @@ server {
     location / { try_files $uri @app; }
     location @app {
         include uwsgi_params;
-        uwsgi_pass flask:5000;
+        uwsgi_pass image-builer-flask:5000;
     }
 
 }

--- a/REST_API/docker-compose.yml
+++ b/REST_API/docker-compose.yml
@@ -3,7 +3,7 @@
 version: '3'
 services:
 
-  flask:
+  image-builer-flask:
     image: image-builder-flask
     build:
       context: .
@@ -11,7 +11,7 @@ services:
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock"
 
-  nginx:
+  image-builer-nginx:
     image: image-builder-nginx
     build:
       context: .
@@ -20,6 +20,6 @@ services:
       - 5000:80
       - 443:443
     depends_on:
-      - flask
+      - image-builer-flask
     volumes:
       - "/home/xopera/certs:/etc/nginx/certs"

--- a/image-builder-rest-blueprint/service.yaml
+++ b/image-builder-rest-blueprint/service.yaml
@@ -529,7 +529,7 @@ topology_template:
           REGISTRY_IP: 154.48.185.207
         volumes:
           - "/var/run/docker.sock:/var/run/docker.sock"
-        alias: flask
+        alias: image-builer-flask
       requirements:
         - host:  image-builder-docker-host
         - network: image-builder-docker-network
@@ -542,7 +542,7 @@ topology_template:
         exposed_ports:  ['443']
         volumes:
           - "/home/xopera/certs:/etc/nginx/certs"
-        alias: nginx
+        alias: image-builer-nginx
       requirements:
         - host:  image-builder-docker-host
         - dependency: image-builder-flask


### PR DESCRIPTION
This PR renames containers to image-builder- in order to differentiate components for different services if deployed to the same docker network.