### PR TITLE
Enhance documentation for docker-image-definition

### DIFF
--- a/REST_API/JSON-build-params/generic/dockerfile-image-variants.json
+++ b/REST_API/JSON-build-params/generic/dockerfile-image-variants.json
@@ -1,0 +1,25 @@
+{
+  "source_type": "dockerfile",
+  "source_url": "https://link/to/Dockerfile",
+  "source_username": "my_optional_username",
+  "source_password": "my_optional_password",
+  "build_context": [
+    {
+      "dir_name": "my_build_context_dir_name",
+      "url": "https://url/to/git/repo/with/build_context.git",
+      "username": "my_username",
+      "password": "my_password_or_token"
+    }
+  ],
+  "target_images": [
+    {
+      "image": "image_name_1",
+      "tag": "image_tag_1"
+    },
+    {
+      "image": "image_name_2",
+      "tag": "image_tag_2",
+      "base": "base_image"
+    }
+  ]
+}


### PR DESCRIPTION
Since image builder got new users and contributors recently, need for better documentation emerged.
This PR document usage of image-builder core engine.
Closes #11 