### PR TITLE
Allow subdir relative build context for Git repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ File inputs.yaml for this mode should follow this template:
 
             # for Git build context
             url: https://url/to/git/repo.git [required with Git build context]
+            subdir: path/to/subdir [optional]
             username: my_username [optional]
             password: my_password_or_token [optional]
 
@@ -92,6 +93,7 @@ File inputs.yaml for this mode should follow this template:
 
             # for Git build context
             url: https://url/to/git/repo.git [required with Git build context]
+            subdir: path/to/subdir [optional]
             username: my_username [optional]
             password: my_password_or_token [optional]
 

--- a/REST_API/app/main/service/image_builder/TOSCA/docker_image_definition.yaml
+++ b/REST_API/app/main/service/image_builder/TOSCA/docker_image_definition.yaml
@@ -37,6 +37,11 @@ data_types:
         type: string
         description: Name of dir with build context
         required: true
+      subdir:
+        type: string
+        description: Path to subdirectory with build context
+        required: false
+        default: ""
       path:
         type: string
         description: Path to dir with build context

--- a/REST_API/app/main/service/image_builder/TOSCA/inputs/generic/inputs-dockerfile.yaml
+++ b/REST_API/app/main/service/image_builder/TOSCA/inputs/generic/inputs-dockerfile.yaml
@@ -10,6 +10,7 @@ source:
       path: /path/to/local/build/context
 
       # for Git build context
+      subdir: path/to/optional/subdir
       url: https://url/to/git/repo.git
       username: my_optional_username
       password: my_optional_password_or_token

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/builder/build.yml
@@ -122,7 +122,12 @@
     - name: Set Git repo clone path
       set_fact:
         dir_name: "{{ build_context.dir_name }}"
-      when: dockerfile_mode and build_context_defined
+      when: dockerfile_mode and build_context_defined and build_context.subdir is not defined
+
+    - name: Set Git repo clone path with subdir definition
+      set_fact:
+        dir_name: "{{ build_context.dir_name }}/{{ build_context.subdir }}"
+      when: dockerfile_mode and build_context_defined and build_context.subdir is defined
 
     - name: Set repo_name when build_context is empty
       set_fact:

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/tests/image_names/test_05_subdir_context.txt
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/tests/image_names/test_05_subdir_context.txt
@@ -1,0 +1,1 @@
+registry_ip/tests/subdir_context:latest

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/tests/tests-json/test_05_subdir_context.json
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/tests/tests-json/test_05_subdir_context.json
@@ -1,0 +1,11 @@
+{
+  "source_type": "Dockerfile",
+  "source_url": "https://raw.githubusercontent.com/mihaTrajbaric/image-builder-test-files/master/no_context/Dockerfile",
+  "build_context": {
+      "dir_name": "image-builder-test-files",
+      "subdir": "no_context",
+      "url": "https://github.com/mihaTrajbaric/image-builder-test-files"
+    },
+  "target_image_name": "tests/subdir_context",
+  "target_image_tag": "latest"
+}

--- a/REST_API/app/main/service/image_builder/TOSCA/playbooks/tests/tests-yaml/test_05_subdir_context.yaml
+++ b/REST_API/app/main/service/image_builder/TOSCA/playbooks/tests/tests-yaml/test_05_subdir_context.yaml
@@ -1,0 +1,11 @@
+source:
+    build_context:
+        dir_name: image-builder-test-files
+        subdir: no_context
+        url: https://github.com/mihaTrajbaric/image-builder-test-files
+    type: dockerfile
+    url: https://raw.githubusercontent.com/mihaTrajbaric/image-builder-test-files/master/no_context/Dockerfile
+target:
+    image_name: tests/subdir_context
+    image_tag: latest
+    registry_ip: localhost:5001

--- a/REST_API/app/main/util/dto.py
+++ b/REST_API/app/main/util/dto.py
@@ -25,7 +25,7 @@ class BuildDto:
     git_context = api.model('git_build_context', {
         'dir_name': fields.String(required=True, description='name of dir, where build context content will be saved, '
                                                              'relative to Dockerfile'),
-
+        'subdir:' fields.String(required=False, description='path to subdirectory within parent where build will be run'),
         'url': fields.String(required=True, description='Git url'),
         'username': fields.String(required=False, description='username for git'),
         'password': fields.String(required=False, description='password for git')

--- a/REST_API/app/main/util/dto.py
+++ b/REST_API/app/main/util/dto.py
@@ -25,7 +25,7 @@ class BuildDto:
     git_context = api.model('git_build_context', {
         'dir_name': fields.String(required=True, description='name of dir, where build context content will be saved, '
                                                              'relative to Dockerfile'),
-        'subdir:' fields.String(required=False, description='path to subdirectory within parent where build will be run'),
+        'subdir': fields.String(required=False, description='path to subdirectory within parent where build will be run'),
         'url': fields.String(required=True, description='Git url'),
         'username': fields.String(required=False, description='username for git'),
         'password': fields.String(required=False, description='password for git')


### PR DESCRIPTION
This adds an optional 'subdir' attribute to the git build context
which allows for the build contet to be set relative to a path
within the cloned repository.

This can be useful in cases where a given repository contains
multiple Dockerfiles in different subdirectories, and the build must
be run relative to the subdirectory itself.