### PR TITLE
Add a CLI convenience wrapper for image builder invocation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,14 @@ pipeline {
                 sh "docker push $docker_registry_ip/image-builder-nginx"
             }
         }
+        stage('Build and push image-builder-cli') {
+            when { tag "*" }
+            steps {
+                sh "cd REST_API; docker build -t image-builder-cli -f Dockerfile-cli ."
+                sh "docker tag image-builder-cli $docker_registry_ip/image-builder-cli"
+                sh "docker push $docker_registry_ip/image-builder-cli"
+            }
+        }
         stage('Push image-builder-flask to DockerHub') {
             when { tag "*" }
             steps {
@@ -78,6 +86,18 @@ pipeline {
                             docker tag image-builder-nginx sodaliteh2020/image-builder-nginx
                             git fetch --tags
                             ./make_docker.sh push sodaliteh2020/image-builder-nginx
+                        """
+                }
+            }
+        }
+        stage('Push image-builder-cli to DockerHub') {
+            when { tag "*" }
+            steps {
+                withDockerRegistry(credentialsId: 'jenkins-sodalite.docker_token', url: '') {
+                    sh  """#!/bin/bash
+                            docker tag image-builder-cli sodaliteh2020/image-builder-cli
+                            git fetch --tags
+                            ./make_docker.sh push sodaliteh2020/image-builder-cli
                         """
                 }
             }

--- a/README.md
+++ b/README.md
@@ -18,6 +18,17 @@ It is also possible to run the image builder in a self-contained container using
 $ image-builder-cli.sh <input.yaml>
 ```
 
+#### Building the image builder CLI
+
+By default, the included `image-builder-cli.sh` script will use the `sodaliteh2020/image-builder-cli` image. If
+developing the image builder locally, local versions of the CLI container can be built with the supplied Dockerfile:
+
+```
+$ cd REST_API && docker build -t <your tag> Dockerfile-cli .
+```
+
+you will then need to fix up the image name in the `image-builder-cli.sh` script to use your local image.
+
 ### How to use image builder
 Image builder has three modes of operating.
 #### TAR

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ By default, the included `image-builder-cli.sh` script will use the `sodaliteh20
 developing the image builder locally, local versions of the CLI container can be built with the supplied Dockerfile:
 
 ```
-$ cd REST_API && docker build -t <your tag> Dockerfile-cli .
+$ cd REST_API && docker build -t <your tag> -f Dockerfile-cli .
 ```
 
 you will then need to fix up the image name in the `image-builder-cli.sh` script to use your local image.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ If using xOpera 0.5.7 via CLI:
     
     opera deploy -i inputs.yaml docker_image_definition.yaml
 
+### Running using the image builder CLI
+
+It is also possible to run the image builder in a self-contained container using a CLI convenience wrapper:
+
+```
+$ image-builder-cli.sh <input.yaml>
+```
+
 ### How to use image builder
 Image builder has three modes of operating.
 #### TAR

--- a/REST_API/Dockerfile-cli
+++ b/REST_API/Dockerfile-cli
@@ -1,0 +1,11 @@
+FROM adaptant/minideb
+
+RUN install_packages python3-pip python3-setuptools
+RUN install_packages git
+RUN pip3 install wheel
+RUN pip3 install opera docker
+
+COPY app/main/service/image_builder/TOSCA/docker_image_definition.yaml /docker_image_definition.yaml
+COPY app/main/service/image_builder/TOSCA/playbooks /playbooks/
+
+CMD [ "opera", "deploy", "-i", "input.yaml", "docker_image_definition.yaml" ]

--- a/REST_API/build_and_push.sh
+++ b/REST_API/build_and_push.sh
@@ -11,6 +11,7 @@ fi
 components=(
   'flask'
   'nginx'
+  'cli'
 )
 
 for component in "${components[@]}"; do

--- a/image-builder-cli.sh
+++ b/image-builder-cli.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+[ $# != 1 ] && echo "Usage: $0 input-file.yaml" && exit 1
+
+get_abs_filename() {
+  # $1 : relative filename
+  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+}
+
+input=$(get_abs_filename $1)
+
+docker run -it -v $input:/input.yaml \
+	   -v /var/run/docker.sock:/var/run/docker.sock \
+	   --net=host \
+	   sodaliteh2020/image-builder

--- a/image-builder-cli.sh
+++ b/image-builder-cli.sh
@@ -12,4 +12,4 @@ input=$(get_abs_filename $1)
 docker run -it -v $input:/input.yaml \
 	   -v /var/run/docker.sock:/var/run/docker.sock \
 	   --net=host \
-	   sodaliteh2020/image-builder
+	   sodaliteh2020/image-builder-cli

--- a/image-builder-cli.sh
+++ b/image-builder-cli.sh
@@ -9,7 +9,22 @@ get_abs_filename() {
 
 input=$(get_abs_filename $1)
 
+get_extra_volume_mounts() {
+  # $1 : input file
+
+  local_dockerfile=$(grep file:\/\/ $1 | sed -e 's/^.*file:\/\///')
+  local_build_context=$(grep path: $1 | sed -e 's/^.*path:[ \t]*//')
+
+  extra_mounts=""
+
+  [ ! -z $local_dockerfile ] && extra_mounts="$extra_mounts -v $local_dockerfile:$local_dockerfile"
+  [ ! -z $local_build_context ] && extra_mounts="$extra_mounts -v $local_build_context:$local_build_context"
+
+  echo $extra_mounts
+}
+
 docker run -it -v $input:/input.yaml \
 	   -v /var/run/docker.sock:/var/run/docker.sock \
+	   $(get_extra_volume_mounts $1) \
 	   --net=host \
 	   sodaliteh2020/image-builder-cli

--- a/image-builder-cli.sh
+++ b/image-builder-cli.sh
@@ -2,18 +2,18 @@
 
 [ $# != 1 ] && echo "Usage: $0 input-file.yaml" && exit 1
 
-get_abs_filename() {
-  # $1 : relative filename
-  echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
+get_abs_path() {
+  # $1 : relative path
+  [ ! -z $1 ] && echo "$(cd "$(dirname "$1")" && pwd)/$(basename "$1")"
 }
 
-input=$(get_abs_filename $1)
+input=$(get_abs_path $1)
 
 get_extra_volume_mounts() {
   # $1 : input file
 
-  local_dockerfile=$(grep file:\/\/ $1 | sed -e 's/^.*file:\/\///')
-  local_build_context=$(grep path: $1 | sed -e 's/^.*path:[ \t]*//')
+  local_dockerfile=$(get_abs_path $(grep file:\/\/ $1 | sed -e 's/^.*file:\/\///'))
+  local_build_context=$(get_abs_path $(grep path: $1 | sed -e 's/^.*path:[ \t]*//'))
 
   extra_mounts=""
 


### PR DESCRIPTION
This adds a self-contained Docker image that enables standalone
execution of the image builder using a passed-in input file, as well
as a convenience script that carries out the invocation.